### PR TITLE
ci: add OpenStack tox validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2244615e3b5ef56a6e83e993ede50ea9c3716cd7 # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2bed598442494c60f1f9ae004626473f7c400bf7 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@0dcf370eb08b3f884992181348b8c41d7f66c10e # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2244615e3b5ef56a6e83e993ede50ea9c3716cd7 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,33 @@ permissions:
   contents: read
 
 jobs:
+  tox:
+    name: tox (${{ matrix.project.repository }})
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@0dcf370eb08b3f884992181348b8c41d7f66c10e # main
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - repository: openstack/requirements
+            ref: 46a7e3927152884c05f1e257c528af593d67b84d
+          - repository: openstack/tempest
+            ref: 538f6af8da510e9286ddc762182cfa7170ad7b03
+          - repository: openstack/barbican-tempest-plugin
+            ref: 2cd185133a86242c58d721e66c2db753a369fe60
+          - repository: openstack/cinder-tempest-plugin
+            ref: 1357d5dccffc2cd6c1e8a13e84c065d5bd55e4d5
+          - repository: openstack/heat-tempest-plugin
+            ref: 1ce78d2eba96678955e3be10096fc239b08ba809
+          - repository: openstack/keystone-tempest-plugin
+            ref: bab7165ee8aef4abb796db587299c773bc105ee1
+          - repository: openstack/neutron-tempest-plugin
+            ref: 9c22c14682afa1168d0e1bd1cd1efb092c28a8fe
+          - repository: openstack/octavia-tempest-plugin
+            ref: 2f3e8a379573dc8c7cb13a5395f55ba00790fe59
+    with:
+      repository: ${{ matrix.project.repository }}
+      ref: ${{ matrix.project.ref }}
+
   image:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- add the shared docker-atmosphere tox reusable workflow to the build workflow
- test only the existing openstack/ checkout targets used by the image build
- keep each tox ref pinned to the same commit currently used by the image checkout
- set caller-level `fail-fast: false` so multi-project matrices report every OpenStack tox result

## Testing
- `nix-shell -p actionlint --run "actionlint .github/workflows/build.yml"`
- GitHub Actions tox checks were allowed to complete on this PR